### PR TITLE
change allow_comment default to true

### DIFF
--- a/lib/ffi_yajl/parser.rb
+++ b/lib/ffi_yajl/parser.rb
@@ -41,7 +41,12 @@ module FFI_Yajl
         raise ArgumentError, "options check_utf8 and dont_validate_strings are both true which conflict"
       end
 
-      yajl_opts[:yajl_allow_comments]         = @opts[:allow_comments]
+      yajl_opts[:yajl_allow_comments]         = true
+
+      if @opts.key?(:allow_comments)
+        yajl_opts[:yajl_allow_comments]       = @opts[:allow_comments]
+      end
+
       yajl_opts[:yajl_dont_validate_strings]  = (@opts[:check_utf8] == false || @opts[:dont_validate_strings])
       yajl_opts[:yajl_allow_trailing_garbage] = @opts[:allow_trailing_garbage]
       yajl_opts[:yajl_allow_multiple_values]  = @opts[:allow_multiple_values]

--- a/spec/ffi_yajl/parser_spec.rb
+++ b/spec/ffi_yajl/parser_spec.rb
@@ -32,6 +32,14 @@ describe "FFI_Yajl::Parser" do
           expect(parser).to eq({"key"=>"value"})
         end
       end
+
+      context "by default" do
+        let(:options) { }
+
+        it "should parse" do
+          expect(parser).to eq({"key"=>"value"})
+        end
+      end
     end
 
     context "when json has multiline comments" do


### PR DESCRIPTION
this matches yajl-ruby's default and fixes a regression in Chef
where we stopped accepting comments.
