### PR TITLE
extconf.rb: remove "-Wl,--no-undefined" from ldflags

### DIFF
--- a/ext/ffi_yajl/ext/encoder/extconf.rb
+++ b/ext/ffi_yajl/ext/encoder/extconf.rb
@@ -8,6 +8,9 @@ RbConfig::MAKEFILE_CONFIG['CC'] = ENV['CC'] if ENV['CC']
 $CFLAGS = " -I#{Libyajl2.include_path} #{$CFLAGS}"
 $LDFLAGS = " -L#{Libyajl2.opt_path} #{$LDFLAGS}"
 
+# remove "-Wl,--no-undefined" flag if existent to allow for loading with dlopen
+$LDFLAGS.slice!("-Wl,--no-undefined")
+
 puts $CFLAGS
 puts $LDFLAGS
 

--- a/ext/ffi_yajl/ext/parser/extconf.rb
+++ b/ext/ffi_yajl/ext/parser/extconf.rb
@@ -8,6 +8,9 @@ RbConfig::MAKEFILE_CONFIG['CC'] = ENV['CC'] if ENV['CC']
 $CFLAGS = "-I#{Libyajl2.include_path} #{$CFLAGS}"
 $LDFLAGS = "-L#{Libyajl2.opt_path} #{$LDFLAGS}"
 
+# remove "-Wl,--no-undefined" flag if existent to allow for loading with dlopen
+$LDFLAGS.slice!("-Wl,--no-undefined")
+
 puts $CFLAGS
 puts $LDFLAGS
 


### PR DESCRIPTION
Remove ldflag "-Wl,--no-undefined" if existent to allow for loading
libyajl with dlopen.

This fixes building the native extensions on systems like gentoo which
set the ldflag "-Wl,--no-undefined" by default.
