### PR TITLE
Move #windows? to lib to allow not checking libname to determine platform

### DIFF
--- a/lib/ffi_yajl/ext.rb
+++ b/lib/ffi_yajl/ext.rb
@@ -4,6 +4,7 @@ require 'ffi_yajl/encoder'
 require 'ffi_yajl/parser'
 require 'ffi'
 require 'libyajl2'
+require 'ffi_yajl/platform'
 
 module FFI_Yajl
   # FIXME: DRY with ffi_yajl/ffi.rb
@@ -11,7 +12,7 @@ module FFI_Yajl
   #        so that the C-library can be installed without FFI
   libname = ::FFI.map_library_name("yajl")
   # awful windows patch, but there is an open issue to entirely replace FFI.map_library_name already
-  libname = "libyajl.so" if libname == "yajl.dll"
+  libname = "libyajl.so" if Platform::windows?
   libpath = File.expand_path(File.join(Libyajl2.opt_path, libname))
   libpath.gsub!(/dylib/, 'bundle')
   libpath = ::FFI.map_library_name("yajl") unless File.exist?(libpath)

--- a/lib/ffi_yajl/platform.rb
+++ b/lib/ffi_yajl/platform.rb
@@ -1,0 +1,5 @@
+module Platform
+  def self.windows?
+    !!(RUBY_PLATFORM =~ /mswin|mingw|cygwin|windows/)
+  end
+end


### PR DESCRIPTION
Not DRY but was unsure of where to include that would be accessible in extconf and /lib but since #windows? was duplicated between parser and encoder extconf anyway and require_relative broke tests I decided to duplicate it.