### PR TITLE
fix error on cygwin.

### DIFF
--- a/lib/ffi_yajl/ext.rb
+++ b/lib/ffi_yajl/ext.rb
@@ -11,7 +11,7 @@ module FFI_Yajl
   #        so that the C-library can be installed without FFI
   libname = ::FFI.map_library_name("yajl")
   # awful windows patch, but there is an open issue to entirely replace FFI.map_library_name already
-  libname = "libyajl.so" if libname == "yajl.dll"
+  libname = "libyajl.so" if /^(?:cyg)?yajl\.dll$/ =~ libname
   libpath = File.expand_path(File.join(Libyajl2.opt_path, libname))
   libpath.gsub!(/dylib/, 'bundle')
   libpath = ::FFI.map_library_name("yajl") unless File.exist?(libpath)


### PR DESCRIPTION
Hi,

I fixed an error on Cygwin.

`::FFI.map_library_name("yajl")` returns `"cygyajl.dll"`, not `"yajl.dll"`.

Please merge it.