### PR TITLE
add :unique_key_checking flag to parser

### DIFF
--- a/ext/ffi_yajl/ext/parser/parser.c
+++ b/ext/ffi_yajl/ext/parser/parser.c
@@ -24,7 +24,7 @@ void set_value(CTX *ctx, VALUE val) {
       rb_ary_push(last, val);
       break;
     case T_HASH:
-      if ( ((CTX *)ctx)->uniqueKeyChecking ) {
+      if ( ctx->uniqueKeyChecking ) {
         ID sym_has_key = rb_intern("has_key?");
         if ( rb_funcall(last, sym_has_key, 1, key) == Qtrue ) {
           rb_raise(cParseError, "repeated key: %s", RSTRING_PTR(key));

--- a/ffi-yajl-universal-java.gemspec
+++ b/ffi-yajl-universal-java.gemspec
@@ -6,6 +6,6 @@ gemspec.platform = "universal-java"
 # extensions so can we simplify the gemspecs now?
 #gemspec.extensions = %w{ ext/libyajl2/extconf.rb }
 
-gemspec.add_dependency "ffi", "~> 1.5"
+gemspec.add_runtime_dependency "ffi", "~> 1.5"
 
 gemspec

--- a/ffi-yajl.gemspec
+++ b/ffi-yajl.gemspec
@@ -3,4 +3,6 @@ gemspec = eval(IO.read(File.expand_path(File.join(File.dirname(__FILE__), "ffi-y
 gemspec.platform = Gem::Platform::RUBY
 gemspec.extensions = %w{ ext/ffi_yajl/ext/encoder/extconf.rb ext/ffi_yajl/ext/parser/extconf.rb ext/ffi_yajl/ext/dlopen/extconf.rb }
 
+gemspec.add_development_dependency "ffi", "~> 1.5"
+
 gemspec

--- a/ffi-yajl.gemspec.shared
+++ b/ffi-yajl.gemspec.shared
@@ -18,7 +18,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rake-compiler", "~> 0.8.3"
   # pin mime-types in order to work on ruby 1.8.7
   s.add_development_dependency "mime-types", "~> 1.16"
-  s.add_development_dependency "ffi", "~> 1.5"
   s.add_dependency "libyajl2", "~> 1.2"
 
   s.bindir       = "bin"

--- a/lib/ffi_yajl/ffi/parser.rb
+++ b/lib/ffi_yajl/ffi/parser.rb
@@ -30,6 +30,9 @@ module FFI_Yajl
           case stack.last
           when Hash
             raise FFI_Yajl::ParseError.new("internal error: missing key in parse") if key.nil?
+            if @opts[:unique_key_checking] && stack.last.has_key?(key)
+              raise FFI_Yajl::ParseError.new("repeated key: #{key}")
+            end
             stack.last[key] = val
           when Array
             stack.last.push(val)

--- a/lib/ffi_yajl/parser.rb
+++ b/lib/ffi_yajl/parser.rb
@@ -75,6 +75,8 @@ module FFI_Yajl
       yajl_opts[:yajl_allow_multiple_values]  = @opts[:allow_multiple_values]
       yajl_opts[:yajl_allow_partial_values]   = @opts[:allow_partial_values]
 
+      yajl_opts[:unique_key_checking]         = @opts[:unique_key_checking]
+
       # XXX: bug-compat with ruby-yajl
       return nil if str == ""
 

--- a/spec/ffi_yajl/parser_spec.rb
+++ b/spec/ffi_yajl/parser_spec.rb
@@ -492,6 +492,21 @@ describe "FFI_Yajl::Parser" do
         expect{ parser }.not_to raise_error
       end
     end
+
+    context "should ignore repeated keys by default" do
+      let(:json) { '{"foo":"bar","foo":"baz"}' }
+      it "should replace the first hash key with the second" do
+        expect(parser).to eql( "foo" => "baz" )
+      end
+    end
+
+    context "should raise an exception for repeated keys" do
+      let(:json) { '{"foo":"bar","foo":"baz"}' }
+      let(:options) { { :unique_key_checking => true } }
+      it "should raise" do
+        expect{ parser }.to raise_error(FFI_Yajl::ParseError)
+      end
+    end
   end
 
   context "when options are set to empty hash" do


### PR DESCRIPTION
can be used to error out if keys are duplicated in input rather than
silently replacing.