### PR TITLE
fix parse error in travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,6 +63,6 @@ matrix:
       jdk: openjdk7
     - rvm: jruby-head
       jdk: openjdk6
- branches:
-   only:
-     - master
+branches:
+  only:
+    - master


### PR DESCRIPTION
Having one space before "branches:" causes `YAML.load` to throw a syntax parse error.