### PR TITLE
Suppress method redefined warnings

### DIFF
--- a/lib/ffi_yajl/parser.rb
+++ b/lib/ffi_yajl/parser.rb
@@ -23,7 +23,8 @@
 module FFI_Yajl
   class ParseError < StandardError; end
   class Parser
-    attr_accessor :stack, :key_stack, :key, :finished
+    attr_writer :stack, :key_stack
+    attr_accessor :key, :finished
 
     attr_accessor :opts
 


### PR DESCRIPTION
    % FORCE_FFI_YAJL=ffi ruby -w -I lib -e 'require "ffi_yajl"'
    lib/ffi_yajl/parser.rb:33: warning: method redefined; discarding old stack
    lib/ffi_yajl/parser.rb:40: warning: method redefined; discarding old key_stack
    ...