### PR TITLE
Suppress assigned but unused variable warning

### DIFF
--- a/lib/ffi_yajl/ffi/encoder.rb
+++ b/lib/ffi_yajl/ffi/encoder.rb
@@ -53,7 +53,6 @@ module FFI_Yajl
         if ( status = FFI_Yajl.yajl_gen_get_buf(yajl_gen, string_ptr, length_ptr) ) != 0
           FFI_Yajl::Encoder.raise_error_for_status(status)
         end
-        length = length_ptr.read_int
         string = string_ptr.get_pointer(0).read_string
 
         FFI_Yajl.yajl_gen_free(yajl_gen)


### PR DESCRIPTION
    % FORCE_FFI_YAJL=ffi ruby -w -I lib -e 'require "ffi_yajl"'
    ...
    lib/ffi_yajl/ffi/encoder.rb:56: warning: assigned but unused variable - length