### PR TITLE
Fix uninitialized instance variable when using ext

### DIFF
--- a/ext/ffi_yajl/ext/parser/parser.c
+++ b/ext/ffi_yajl/ext/parser/parser.c
@@ -184,6 +184,7 @@ static VALUE mParser_do_yajl_parse(VALUE self, VALUE str, VALUE yajl_opts) {
   unsigned char *err;
   volatile CTX ctx;
 
+  rb_ivar_set(self, rb_intern("key"), Qnil);
   rb_ivar_set(self, rb_intern("stack"), rb_ary_new());
   rb_ivar_set(self, rb_intern("key_stack"), rb_ary_new());
 


### PR DESCRIPTION
Fixes a ruby warning for uninitialized instance variable. I tried to make this appear in the tests by configuring warnings for RSpec, but it seems this warning doesn't occur when the FFI backend is also loaded. (Also there were warnings for other stuff like `warning: setting Encoding.default_internal` which is clearly intentional so I'd have to do a bunch of work to wrap that in a "warnings ok block").

@lamont-granquist 