### PR TITLE
fix uninitialized constant errors

### DIFF
--- a/lib/ffi_yajl/ext.rb
+++ b/lib/ffi_yajl/ext.rb
@@ -27,6 +27,10 @@ require 'ffi_yajl/parser'
 require 'ffi_yajl/ext/dlopen'
 require 'ffi_yajl/map_library_name'
 
+# needed so the encoder c-code can find these symbols
+require 'stringio'
+require 'date'
+
 module FFI_Yajl
   extend FFI_Yajl::MapLibraryName
   extend FFI_Yajl::Ext::Dlopen


### PR DESCRIPTION
c extension needs stringio and date required first in order to find
those constants.