### PR TITLE
fix validate_utf8: false encoding coercion

### DIFF
--- a/lib/ffi_yajl/encoder.rb
+++ b/lib/ffi_yajl/encoder.rb
@@ -47,7 +47,7 @@ module FFI_Yajl
         if str.respond_to?(:scrub)
           str.scrub!
         else
-          str.encode!("UTF-8", undef: :replace, invalid: :replace)
+          str.encode!("UTF-16le", undef: :replace, invalid: :replace).encode!('UTF-8')
         end
       end
       str
@@ -68,7 +68,7 @@ module FFI_Yajl
       if token.respond_to?(:scrub)
         token.scrub!
       else
-        token.encode("utf-8", undef: :replace, invalid: :replace)
+        token.encode!("UTF-16le", undef: :replace, invalid: :replace).encode!('UTF-8')
       end
       case status
       when 1 # yajl_gen_keys_must_be_strings

--- a/lib/ffi_yajl/encoder.rb
+++ b/lib/ffi_yajl/encoder.rb
@@ -47,7 +47,7 @@ module FFI_Yajl
         if str.respond_to?(:scrub)
           str.scrub!
         else
-          str.encode!("UTF-8", 'binary', undef: :replace, invalid: :replace)
+          str.encode!("UTF-8", undef: :replace, invalid: :replace)
         end
       end
       str
@@ -68,7 +68,7 @@ module FFI_Yajl
       if token.respond_to?(:scrub)
         token.scrub!
       else
-        token.encode("utf-8", 'binary', undef: :replace, invalid: :replace)
+        token.encode("utf-8", undef: :replace, invalid: :replace)
       end
       case status
       when 1 # yajl_gen_keys_must_be_strings

--- a/lib/ffi_yajl/encoder.rb
+++ b/lib/ffi_yajl/encoder.rb
@@ -41,7 +41,7 @@ module FFI_Yajl
       # call either the ext or ffi hook
       str = do_yajl_encode(obj, yajl_gen_opts, opts)
       # we can skip cleaning the whole string for utf-8 issues if we have yajl validate as we go
-      str.encode!("utf-8", "binary", undef: :replace) unless yajl_gen_opts[:yajl_gen_validate_utf8]
+      str.force_encoding("UTF-8").encode!("UTF-8", undef: :replace, invalid: :replace) unless yajl_gen_opts[:yajl_gen_validate_utf8]
       str
     end
 
@@ -56,7 +56,7 @@ module FFI_Yajl
 
     def self.raise_error_for_status(status, token = nil)
       # scrub token to valid utf-8 since we may be issuing an exception on an invalid utf-8 token
-      token = token.to_s.encode("utf-8", "binary", undef: :replace)
+      token = token.to_s.force_encoding("UTF-8").encode("utf-8", undef: :replace, invalid: :replace)
       case status
       when 1 # yajl_gen_keys_must_be_strings
         raise FFI_Yajl::EncodeError, "YAJL internal error: attempted use of non-string object as key"

--- a/spec/ffi_yajl/encoder_spec.rb
+++ b/spec/ffi_yajl/encoder_spec.rb
@@ -209,6 +209,13 @@ describe "FFI_Yajl::Encoder" do
         json = encoder.encode(ruby)
         expect(json).to match(/Hañs Helmüt/)
       end
+
+      it "does not grow after a round trip" do
+        json = encoder.encode(ruby)
+        ruby2 = FFI_Yajl::Parser.parse(json)
+        json2 = encoder.encode(ruby2)
+        expect(json).to eql(json2)
+      end
     end
   end
 end

--- a/spec/ffi_yajl/encoder_spec.rb
+++ b/spec/ffi_yajl/encoder_spec.rb
@@ -180,6 +180,7 @@ describe "FFI_Yajl::Encoder" do
           "passwd" => {
             "root" => { "dir" => "/root", "gid" => 0, "uid" => 0, "shell" => "/bin/sh", "gecos" => "Elan Ruusam\xc3\xa4e" },
             "glen" => { "dir" => "/home/glen", "gid" => 500, "uid" => 500, "shell" => "/bin/bash", "gecos" => "Elan Ruusam\xE4e" },
+            "helmüt" => { "dir" => "/home/helmüt", "gid" => 500, "uid" => 500, "shell" => "/bin/bash", "gecos" => "Hañs Helmüt" },
           },
         },
       },
@@ -202,6 +203,11 @@ describe "FFI_Yajl::Encoder" do
 
       it "returns valid utf8" do
         expect( encoder.encode(ruby).valid_encoding? ).to be true
+      end
+
+      it "does not mangle valid utf8" do
+        json = encoder.encode(ruby)
+        expect(json).to match(/Hañs Helmüt/)
       end
     end
   end

--- a/spec/ffi_yajl/encoder_spec.rb
+++ b/spec/ffi_yajl/encoder_spec.rb
@@ -187,7 +187,7 @@ describe "FFI_Yajl::Encoder" do
     }
 
     it "raises an error on invalid json" do
-      expect { encoder.encode(ruby) }.to raise_error(FFI_Yajl::EncodeError, /Invalid UTF-8 string 'Elan Ruusam.e': cannot encode to UTF-8/)
+      expect { encoder.encode(ruby) }.to raise_error(FFI_Yajl::EncodeError, /Invalid UTF-8 string 'Elan Ruusam.*': cannot encode to UTF-8/)
     end
 
     context "when validate_utf8 is off" do


### PR DESCRIPTION
the string we get back from ffi is tagged as ascii encoded by default,
so we must force encode it first.

then we don't want to convert from binary to utf-8 since that will wind
up mangling all the utf-8 characters, we want to convert from utf-8
to utf-8 while replacing invalid characters.