### PR TITLE
Use versioned .so file.

### DIFF
--- a/lib/ffi_yajl/map_library_name.rb
+++ b/lib/ffi_yajl/map_library_name.rb
@@ -47,13 +47,13 @@ module FFI_Yajl
     def library_names
       case host_os
       when /mingw|mswin/
-        [ "libyajl.so", "yajl.dll" ]
+        [ "libyajl.so.2", "yajl.dll" ]
       when /cygwin/
-        [ "libyajl.so", "cygyajl.dll" ]
+        [ "libyajl.so.2", "cygyajl.dll" ]
       when /darwin/
         [ "libyajl.bundle", "libyajl.dylib" ]
       else
-        [ "libyajl.so" ]
+        [ "libyajl.so.2" ]
       end
     end
 

--- a/spec/ffi_yajl/map_library_name_spec.rb
+++ b/spec/ffi_yajl/map_library_name_spec.rb
@@ -27,17 +27,17 @@ class Test
 end
 
 host_os_library_name_mapping = {
-  "mingw"    => [ "libyajl.so", "yajl.dll" ],
-  "mswin"    => [ "libyajl.so", "yajl.dll" ],
-  "cygwin"   => [ "libyajl.so", "cygyajl.dll" ],
+  "mingw"    => [ "libyajl.so.2", "yajl.dll" ],
+  "mswin"    => [ "libyajl.so.2", "yajl.dll" ],
+  "cygwin"   => [ "libyajl.so.2", "cygyajl.dll" ],
   "darwin"   => [ "libyajl.bundle", "libyajl.dylib" ],
-  "solaris2" => [ "libyajl.so" ],
-  "linux"    => [ "libyajl.so" ],
-  "aix"      => [ "libyajl.so" ],
-  "hpux"     => [ "libyajl.so" ],
-  "netbsd"   => [ "libyajl.so" ],
-  "openbsd"  => [ "libyajl.so" ],
-  "freebsd"  => [ "libyajl.so" ],
+  "solaris2" => [ "libyajl.so.2" ],
+  "linux"    => [ "libyajl.so.2" ],
+  "aix"      => [ "libyajl.so.2" ],
+  "hpux"     => [ "libyajl.so.2" ],
+  "netbsd"   => [ "libyajl.so.2" ],
+  "openbsd"  => [ "libyajl.so.2" ],
+  "freebsd"  => [ "libyajl.so.2" ],
 }
 
 describe "FFI_Yajl::MapLibraryName" do


### PR DESCRIPTION
Using non-versioned .so file is wrong. This file is used intended to be
used just by linker. This file is typically just symlink to the
versioned .so file. Most distributions ships this file in -devel
subpackage and it is not installed on user system, nor it is required
for runtime.

Also, ffi_yajl depends on yajl version 2 and no other, so requiring the
versioned .so file is correct also from this POV.

Here are Fedora packaging guidelines which elaborates a bit about this:

https://fedoraproject.org/wiki/Packaging:Guidelines#Devel_Packages

Please note that this was originally reported in #35.