### PR TITLE
Allow to use system yajl via FFI.

### DIFF
--- a/lib/ffi_yajl/map_library_name.rb
+++ b/lib/ffi_yajl/map_library_name.rb
@@ -96,7 +96,7 @@ module FFI_Yajl
     # @api private
     def ffi_open_yajl_library
       found = false
-      expanded_library_names.each do |libname|
+      ( expanded_library_names + library_names ).each do |libname|
         begin
           ffi_lib libname
           found = true


### PR DESCRIPTION
When the libyajl2 gem is installed with "USE_SYSTEM_LIBYAJL2", the FFI cannot load the system yajl library. This PR fixes it.