### PR TITLE
Fix license.

### DIFF
--- a/ffi-yajl.gemspec.shared
+++ b/ffi-yajl.gemspec.shared
@@ -5,7 +5,7 @@ Gem::Specification.new do |s|
   s.name             = 'ffi-yajl'
   s.version          = FFI_Yajl::VERSION
   s.extra_rdoc_files = ["README.md", "LICENSE" ]
-  s.license          = "Apache-2.0"
+  s.license          = "MIT"
   s.summary          = "Ruby FFI wrapper around YAJL 2.x"
   s.description      = s.summary
   s.author           = "Lamont Granquist"


### PR DESCRIPTION
It seems that the license referenced in .gemspec is wrong, since every file in the repository mentions MIT, while no file mentions ASL.