### PR TITLE
API docs: Avoid YARD warning

### DIFF
--- a/lib/ffi_yajl/map_library_name.rb
+++ b/lib/ffi_yajl/map_library_name.rb
@@ -34,7 +34,7 @@ module FFI_Yajl
     # Stub for tests to override the host_os
     #
     # @api private
-    # @return Array<String> lower case ruby host_os string
+    # @return [Array<String>] lower case ruby host_os string
     def host_os
       RbConfig::CONFIG["host_os"].downcase
     end
@@ -43,7 +43,7 @@ module FFI_Yajl
     # and Mac may have different names/extensions.
     #
     # @api private
-    # @return Array<String> Array of yajl library names for platform
+    # @return [Array<String>] Array of yajl library names for platform
     def library_names
       case host_os
       when /mingw|mswin/
@@ -63,7 +63,7 @@ module FFI_Yajl
     # the filesystem.  May return an empty array.
     #
     # @api private
-    # @return Array<String> Array of full paths to libyajl2 gem libraries
+    # @return [Array<String>] Array of full paths to libyajl2 gem libraries
     def expanded_library_names
       library_names.map do |libname|
         pathname = File.expand_path(File.join(Libyajl2.opt_path, libname))


### PR DESCRIPTION
## Description

This PR updates the YARD docstring annotations to avoid a warning.

<details>

```
Building YARD (yri) index for ffi-yajl-2.3.1...
lib/ffi_yajl/map_library_name.rb:37: [InvalidTagFormat] Invalid tag format for @return
lib/ffi_yajl/map_library_name.rb:46: [InvalidTagFormat] Invalid tag format for @return
lib/ffi_yajl/map_library_name.rb:66: [InvalidTagFormat] Invalid tag format for @return
```

</details>

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document. (PS: It's blank!)
- [x] I have updated the documentation accordingly.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
