### PR TITLE
CI: Use 2.4.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ bundler_args: --without development_extras --jobs 3 --retry 3
 after_success: gem install yajl-ruby; gem install json; gem install psych; FORCE_FFI_YAJL="ext" ffi-yajl-bench
 matrix:
   include:
-    - rvm: 2.2.10
     - rvm: 2.3.8
     - rvm: 2.4.6
     - rvm: ruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: ruby
-sudo: false
 dist: trusty
 
 before_install:
@@ -13,7 +12,7 @@ matrix:
   include:
     - rvm: 2.2.10
     - rvm: 2.3.8
-    - rvm: 2.4.5
+    - rvm: 2.4.6
     - rvm: ruby-head
     - rvm: rbx
     - rvm: jruby


### PR DESCRIPTION
This PR updates the CI matrix to

- **Use latest Ruby 2.4** release.
- Drop 2.2 - it is EOL.

## Description

Also: Removes an old setting from Travis. See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration


