### PR TITLE
CI: Drop 2.3.8 from testing matrix (EOL in 2019-03-31)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ bundler_args: --without development_extras --jobs 3 --retry 3
 after_success: gem install yajl-ruby; gem install json; gem install psych; FORCE_FFI_YAJL="ext" ffi-yajl-bench
 matrix:
   include:
-    - rvm: 2.3.8
     - rvm: 2.4.6
     - rvm: ruby-head
     - rvm: rbx


### PR DESCRIPTION
### Description

This PR updates the CI matrix to **remove Ruby 2.3.8**, since it's out of support.

Blog post: https://www.ruby-lang.org/en/news/2019/03/31/support-of-ruby-2-3-has-ended/

### Issues Resolved

N/A. A comment in #99 made me think of end-of-life announcements.

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [x] PR title is a worthy inclusion in the CHANGELOG