### PR TITLE
Substitute require for require_relative

### DIFF
--- a/lib/ffi_yajl.rb
+++ b/lib/ffi_yajl.rb
@@ -35,16 +35,16 @@
 # - Then we try the c-ext and rescue into ffi that fails
 #
 if ENV["FORCE_FFI_YAJL"] == "ext"
-  require "ffi_yajl/ext"
+  require_relative "ffi_yajl/ext"
 elsif ENV["FORCE_FFI_YAJL"] == "ffi"
-  require "ffi_yajl/ffi"
+  require_relative "ffi_yajl/ffi"
 elsif RUBY_PLATFORM == "java"
-  require "ffi_yajl/ffi"
+  require_relative "ffi_yajl/ffi"
 else
   begin
-    require "ffi_yajl/ext"
+    require_relative "ffi_yajl/ext"
   rescue LoadError
     warn "failed to load the ffi-yajl c-extension, falling back to ffi interface"
-    require "ffi_yajl/ffi"
+    require_relative "ffi_yajl/ffi"
   end
 end

--- a/lib/ffi_yajl/benchmark/encode.rb
+++ b/lib/ffi_yajl/benchmark/encode.rb
@@ -13,7 +13,7 @@ if !defined?(RUBY_ENGINE) || RUBY_ENGINE !~ /jruby/
 else
   puts "INFO: skipping yajl-ruby on jruby"
 end
-require "ffi_yajl"
+require_relative "../../ffi_yajl"
 begin
   require "json"
 rescue LoadError

--- a/lib/ffi_yajl/benchmark/encode_profile.rb
+++ b/lib/ffi_yajl/benchmark/encode_profile.rb
@@ -2,7 +2,7 @@
 # See MIT-LICENSE
 
 require "rubygems"
-require "ffi_yajl"
+require_relative "../../ffi_yajl"
 begin
   require "perftools"
 rescue LoadError

--- a/lib/ffi_yajl/benchmark/parse.rb
+++ b/lib/ffi_yajl/benchmark/parse.rb
@@ -1,7 +1,7 @@
 require "rubygems"
 require "benchmark"
 require "yajl"
-require "ffi_yajl"
+require_relative "../../ffi_yajl"
 if !defined?(RUBY_ENGINE) || RUBY_ENGINE !~ /jruby/
   begin
     require "yajl"

--- a/lib/ffi_yajl/benchmark/parse_profile.rb
+++ b/lib/ffi_yajl/benchmark/parse_profile.rb
@@ -2,7 +2,7 @@
 # See MIT-LICENSE
 
 require "rubygems"
-require "ffi_yajl"
+require_relative "../../ffi_yajl"
 begin
   require "perftools"
 rescue LoadError

--- a/lib/ffi_yajl/benchmark/parse_profile_ruby_prof.rb
+++ b/lib/ffi_yajl/benchmark/parse_profile_ruby_prof.rb
@@ -2,7 +2,7 @@
 # See MIT-LICENSE
 
 require "rubygems"
-require "ffi_yajl"
+require_relative "../../ffi_yajl"
 
 module FFI_Yajl
   class Benchmark

--- a/lib/ffi_yajl/ext.rb
+++ b/lib/ffi_yajl/ext.rb
@@ -22,10 +22,10 @@
 
 require "rubygems"
 
-require "ffi_yajl/encoder"
-require "ffi_yajl/parser"
+require_relative "encoder"
+require_relative "parser"
 require "ffi_yajl/ext/dlopen"
-require "ffi_yajl/map_library_name"
+require_relative "map_library_name"
 
 # needed so the encoder c-code can find these symbols
 require "stringio"

--- a/lib/ffi_yajl/ffi.rb
+++ b/lib/ffi_yajl/ffi.rb
@@ -31,7 +31,7 @@ rescue LoadError
   exit 1
 end
 
-require "ffi_yajl/map_library_name"
+require_relative "map_library_name"
 
 module FFI_Yajl
   extend ::FFI::Library
@@ -137,17 +137,17 @@ module FFI_Yajl
   attach_function :yajl_gen_clear, [:yajl_gen], :void
 end
 
-require "ffi_yajl/encoder"
-require "ffi_yajl/parser"
+require_relative "encoder"
+require_relative "parser"
 
 module FFI_Yajl
   class Parser
-    require "ffi_yajl/ffi/parser"
+    require_relative "ffi/parser"
     include FFI_Yajl::FFI::Parser
   end
 
   class Encoder
-    require "ffi_yajl/ffi/encoder"
+    require_relative "ffi/encoder"
     include FFI_Yajl::FFI::Encoder
   end
 end


### PR DESCRIPTION
require_relative is significantly faster and should be used when available.

Signed-off-by: Tim Smith <tsmith@chef.io>