### PR TITLE
Optimize our requires

### DIFF
--- a/bin/ffi-yajl-bench
+++ b/bin/ffi-yajl-bench
@@ -2,7 +2,7 @@
 
 $LOAD_PATH << File.expand_path(File.join(File.dirname( File.symlink?(__FILE__) ? File.readlink(__FILE__) : __FILE__ ), "../lib"))
 
-require "optparse"
+require "optparse" unless defined?(OptionParser)
 require "ffi_yajl/benchmark"
 
 opts = {}

--- a/ext/ffi_yajl/ext/dlopen/extconf.rb
+++ b/ext/ffi_yajl/ext/dlopen/extconf.rb
@@ -1,6 +1,6 @@
 # rubocop:disable Style/GlobalVars
 require "mkmf"
-require "rubygems"
+require "rubygems" unless defined?(Gem)
 
 RbConfig::MAKEFILE_CONFIG["CC"] = ENV["CC"] if ENV["CC"]
 

--- a/ext/ffi_yajl/ext/encoder/extconf.rb
+++ b/ext/ffi_yajl/ext/encoder/extconf.rb
@@ -1,6 +1,6 @@
 # rubocop:disable Style/GlobalVars
 require "mkmf"
-require "rubygems"
+require "rubygems" unless defined?(Gem)
 require "libyajl2"
 
 RbConfig::MAKEFILE_CONFIG["CC"] = ENV["CC"] if ENV["CC"]

--- a/ext/ffi_yajl/ext/parser/extconf.rb
+++ b/ext/ffi_yajl/ext/parser/extconf.rb
@@ -1,6 +1,6 @@
 # rubocop:disable Style/GlobalVars
 require "mkmf"
-require "rubygems"
+require "rubygems" unless defined?(Gem)
 require "libyajl2"
 
 RbConfig::MAKEFILE_CONFIG["CC"] = ENV["CC"] if ENV["CC"]

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,7 +31,7 @@ rescue LoadError
   puts "WARN: yajl cannot be loaded, expected if this is jruby"
 end
 
-require "ffi_yajl"
+require "ffi_yajl" unless defined?(FFI_Yajl)
 
 RSpec.configure do |conf|
   conf.filter_run_excluding unix_only: true unless RUBY_PLATFORM !~ /mswin|mingw|windows/


### PR DESCRIPTION
Avoid requiring things that are already defined. Rubygems is very slow at traversing the filesystem.

Signed-off-by: Tim Smith <tsmith@chef.io>