### PR TITLE
Fix build on darwin aarch64

### DIFF
--- a/ext/ffi_yajl/ext/encoder/extconf.rb
+++ b/ext/ffi_yajl/ext/encoder/extconf.rb
@@ -12,6 +12,8 @@ $LDFLAGS = " -L#{Libyajl2.opt_path} #{$LDFLAGS}"
 # remove "-Wl,--no-undefined" flag if existent to allow for loading with dlopen
 $LDFLAGS.slice!("-Wl,--no-undefined")
 
+$LDFLAGS << " -Wl,-undefined,dynamic_lookup" if RUBY_PLATFORM =~ /darwin/
+
 puts $CFLAGS
 puts $LDFLAGS
 

--- a/ext/ffi_yajl/ext/parser/extconf.rb
+++ b/ext/ffi_yajl/ext/parser/extconf.rb
@@ -12,6 +12,8 @@ $LDFLAGS = "-L#{Libyajl2.opt_path} #{$LDFLAGS}"
 # remove "-Wl,--no-undefined" flag if existent to allow for loading with dlopen
 $LDFLAGS.slice!("-Wl,--no-undefined")
 
+$LDFLAGS << " -Wl,-undefined,dynamic_lookup" if RUBY_PLATFORM =~ /darwin/
+
 puts $CFLAGS
 puts $LDFLAGS
 


### PR DESCRIPTION
### Description

Extensions weren't building on macOS aarch64 due to an inability to find symbols at link-time.

### Issues Resolved

- #115

### Check List

- [x] All tests pass

  - `rake spec` -> `454 examples, 0 failures, 18 pending`
  - `rake spec:ext` -> `454 examples, 0 failures, 18 pending`
  - `rake spec:ffi` -> `454 examples, 0 failures, 18 pending`

- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>

- [x] PR title is a worthy inclusion in the CHANGELOG