### PR TITLE
Remove 2.4 and 2.5 pipelines

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -1,30 +1,6 @@
 steps:
 
 # Allow ruby-2.4 to softfail since it was configured so in travis too
-- label: ":ruby: 2.4"
-  command:
-    - .expeditor/buildkite/run_linux_tests.sh
-  soft_fail:
-      - exit_status: 1
-  expeditor:
-    executor:
-      docker:
-        image: ruby:2.4
-        environment:
-          - BUNDLE_GEMFILE=/workdir/Gemfile
-          - FORCE_FFI_YAJL="ext"
-
-- label: ":ruby: 2.5"
-  command:
-    - .expeditor/buildkite/run_linux_tests.sh
-  expeditor:
-    executor:
-      docker:
-        image: ruby:2.5
-        environment:
-          - BUNDLE_GEMFILE=/workdir/Gemfile
-          - FORCE_FFI_YAJL="ext"
-
 - label: ":ruby: 2.6"
   command:
     - .expeditor/buildkite/run_linux_tests.sh


### PR DESCRIPTION
### Description

Ruby 2.4 and 2.5 are end of life and the latest changes are for Xcode 14 and Ruby 3.1 under UCRT in Windows.

### Issues Resolved

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [] PR title is a worthy inclusion in the CHANGELOG