### PR TITLE
Updated README with libyajl2 warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,12 @@ ffi-yajl is a Ruby adapter for the [yajl](http://lloyd.github.io/yajl/) JSON par
 
 ## How to Install
 
-Install from the command-line:
+**Warning** if building through Omnibus, a preinstalled ffi-yajl and libyajl2-gem version not matching the bundled version of the project you're attempting to build (e.g., Chef) may cause:
+
+`cannot find -lyajldll: No such file or directory`
+
+
+### Install from the command-line:
 
 ```
 gem install ffi-yajl

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ ffi-yajl is a Ruby adapter for the [yajl](http://lloyd.github.io/yajl/) JSON par
 
 `cannot find -lyajldll: No such file or directory`
 
+If your build script ends up up in this state, a short term fix is `gem uninstall -I libyajl2` before the failing `bundle install`
+
 
 ### Install from the command-line:
 


### PR DESCRIPTION
### Description

omnibus image misbehaves (such as omnibus 3.0.0 built into `chefes/omnibus-toolchain-windows-2019:3.0.0`) because `ffi-yajl` `2.4` is already installed, which as cleaned up the build artifacts for `libyajl2-gem` causing the `libyajldll.a` to not be found on install of a second `ffi-yajl` version. Only seems to break on bundling, though.

### Issues Resolved

Can repost [#114](https://github.com/chef/ffi-yajl/pull/114) now under 2.6


### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG