### PR TITLE
Undefine allocation function for C extension class

### DIFF
--- a/ext/ffi_yajl/ext/encoder/encoder.c
+++ b/ext/ffi_yajl/ext/encoder/encoder.c
@@ -360,6 +360,7 @@ void Init_encoder() {
   mExt = rb_define_module_under(mFFI_Yajl, "Ext");
   mEncoder = rb_define_module_under(mExt, "Encoder");
   cYajl_Gen = rb_define_class_under(mEncoder, "YajlGen", rb_cObject);
+  rb_undef_alloc_func(cYajl_Gen);
   rb_define_method(mEncoder, "do_yajl_encode", mEncoder_do_yajl_encode, 3);
 
   /* use rb_const_get instead of rb_define_class so that we don't get superclass mismatches */


### PR DESCRIPTION
Ruby 3.2 adds a new warning is printed when a Ruby class created in a C extension does not specify an allocate function or undefine it:

```
warning: undefining the allocator of T_DATA class FFI_Yajl::Ext::Encoder::YajlGen
```

As described in https://bugs.ruby-lang.org/issues/18007 and https://github.com/ruby/ruby/blob/7317f96727725ca37ddb06011918deb841de371c/doc/extension.rdoc#label-Write+the+C+Code, we only need to define an allocate function if the class uses a C struct and stores any values on it.

Closes https://github.com/chef/ffi-yajl/issues/123

### Description

[Please describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [x] PR title is a worthy inclusion in the CHANGELOG