### PR TITLE
Remove bogus yajl gem runtime dependency

### DIFF
--- a/ffi-yajl-universal-mingw-ucrt.gemspec
+++ b/ffi-yajl-universal-mingw-ucrt.gemspec
@@ -23,8 +23,6 @@ Gem::Specification.new do |s|
   s.require_path = "lib"
   s.files        = %w{ LICENSE } + Dir.glob( "{bin,lib,ext}/**/*", File::FNM_DOTMATCH ).reject { |f| File.directory?(f) }
 
-  s.add_dependency "yajl"
-
   s.add_development_dependency "cookstyle", "~> 8.1"
 
   s.platform = Gem::Platform.new(%w{universal mingw-ucrt})

--- a/ffi-yajl.gemspec
+++ b/ffi-yajl.gemspec
@@ -24,8 +24,6 @@ Gem::Specification.new do |s|
   s.require_path = "lib"
   s.files        = %w{ LICENSE } + Dir.glob( "{bin,lib,ext}/**/*", File::FNM_DOTMATCH ).reject { |f| File.directory?(f) }
 
-  s.add_dependency "yajl"
-
   s.add_development_dependency "cookstyle", "~> 8.1"
   s.platform = Gem::Platform::RUBY
 end


### PR DESCRIPTION
The "yajl" gem on RubyGems is yajl-logger, an abandoned logging helper
that ships its own lib/yajl.rb. When activated alongside yajl-ruby (or
when anything does `require "yajl"` expecting the C bindings), it
shadows the real loader and breaks consumers like multi_json's yajl
adapter (NameError: uninitialized constant Yajl::ParseError).

The dependency was added by mistake in 145dd21 next to the libyajl2
line and is not referenced anywhere in this gem's source. Removing it
from both gemspecs.

Fixes #142

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
Signed-off-by: Lance Albertson <lance@osuosl.org>

### Description

[Please describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG